### PR TITLE
Articleに関するAPIのルーティングを実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+        # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+    end
+  end
 end


### PR DESCRIPTION
・endpoint は /api/v1 から始める
・/api/v1/articles で CRUD 処理ができるような endpoint が生えるようにroutes.rb を修正した