### PR TITLE
active_model_serializers を使って、記事の一覧を json で返す機能を実装

### DIFF
--- a/app/controllers/api/vi/article_preview_serializer.rb
+++ b/app/controllers/api/vi/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/controllers/api/vi/articles_controller.rb
+++ b/app/controllers/api/vi/articles_controller.rb
@@ -1,0 +1,9 @@
+module Api::V1
+  # base_api_controller を継承
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/controllers/api/vi/user_serializer.rb
+++ b/app/controllers/api/vi/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
-    user { nil }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,5 +1,22 @@
 require "rails_helper"
 
-RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
 end


### PR DESCRIPTION
active_model_serializers を使って、記事の一覧を json で返す機能を実装
request spec を実装