### PR TITLE
記事詳細の実装

### DIFF
--- a/app/controllers/api/vi/article_serializer.rb
+++ b/app/controllers/api/vi/article_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/controllers/api/vi/articles_controller.rb
+++ b/app/controllers/api/vi/articles_controller.rb
@@ -5,5 +5,10 @@ module Api::V1
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
+
+    def show
+      article = Article.find(params[:id])
+      render json: article
+    end
   end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -22,7 +22,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Max: 10
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ
@@ -47,7 +47,8 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  AggregateFailuresByDefault: true
+  # AggregateFailuresByDefault: true
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,22 +1,5 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Articles", type: :request do
-  describe "GET /articles" do
-    subject { get(api_v1_articles_path) }
-
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
-
-    it "記事一覧が取得できる" do
-      subject
-      res = JSON.parse(response.body)
-
-      expect(response).to have_http_status(:ok)
-      expect(res.length).to eq 3
-      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
-      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-    end
-  end
+RSpec.describe Article, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/requests/api/vi/articles_spec.rb
+++ b/spec/requests/api/vi/articles_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+
+  describe "GET /articles/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    context "指定したidの記事が存在する場合" do
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
+
+      it "任意の記事の値が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    context "指定したidの記事が存在しない場合" do
+      let(:article_id) { 10000 }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end


### PR DESCRIPTION
記事詳細のAPIとテストの実装。
・記事の詳細に関しては誰でもみれるようにする
・記事詳細の日付はフロントで表示する際に、更新日をもとに表示する